### PR TITLE
Limit image load concurrency

### DIFF
--- a/ImageLoader.js
+++ b/ImageLoader.js
@@ -1,10 +1,21 @@
 var ImageBuffer = require('./ImageBuffer');
 var ImageInfo = require('./ImageInfo');
 var Promise = require('bluebird');
+var Queue = require('promise-queue');
+
+Queue.configure(Promise);
+
+var maxConcurrent = (
+  process.env.DEVKIT_SPRITER_LOADING_CONCURRENCY
+    ? parseInt(process.env.DEVKIT_SPRITER_LOADING_CONCURRENCY)
+    : 200
+);
+
+var queue = new Queue(maxConcurrent, Infinity);
 
 module.exports = ImageLoader;
 
-function ImageLoader() {}
+function ImageLoader () {}
 
 ImageLoader.prototype.load = function (images, scale) {
   var errors = {};
@@ -27,15 +38,17 @@ ImageLoader.prototype.load = function (images, scale) {
 };
 
 ImageLoader.prototype.get = function (filename, scale) {
-  return new ImageBuffer({filename: filename})
-    .load()
-    .then(function (buffer) {
-      if (scale && scale !== 1) {
-        var width = Math.ceil(buffer.bitmap.width * scale);
-        var height = Math.ceil(buffer.bitmap.height * scale);
-        buffer.resize(width, height);
-      }
+  return queue.add(function () {
+    return new ImageBuffer({filename: filename})
+      .load()
+      .then(function (buffer) {
+        if (scale && scale !== 1) {
+          var width = Math.ceil(buffer.bitmap.width * scale);
+          var height = Math.ceil(buffer.bitmap.height * scale);
+          buffer.resize(width, height);
+        }
 
-      return new ImageInfo(filename, buffer, scale);
-    });
+        return new ImageInfo(filename, buffer, scale);
+      });
+  });
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "devkit-spriter",
   "repository": "https://github.com/gameclosure/devkit-spriter",
   "author": "Martin Hunt",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "description": "a 2D spriter for the DevKit game engine",
   "dependencies": {
     "bluebird": "^2.10.2",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "devkit-spriter",
   "repository": "https://github.com/gameclosure/devkit-spriter",
   "author": "Martin Hunt",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "a 2D spriter for the DevKit game engine",
   "dependencies": {
     "bluebird": "^2.10.2",
     "graceful-fs": "^4.1.2",
-    "jimp": "^0.2.27"
+    "jimp": "^0.2.27",
+    "promise-queue": "^2.2.3"
   }
 }


### PR DESCRIPTION
**Problem:**
Creating spritesheets with lots of images sometimes resulted in "too many open files" error.

**Solution:**
Limit the number of concurrently loaded images.

**Notes:**
The limit is set to `200`. If there's need to modify it, you can specify the limit with `DEVKIT_SPRITER_LOADING_CONCURRENCY` env variable:

```
$ DEVKIT_SPRITER_LOADING_CONCURRENCY=500 npm run build
```