### PR TITLE
Fix rare infinite loop

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/layout.js
+++ b/layout.js
@@ -1,6 +1,6 @@
 var Spritesheet = require('./Spritesheet');
 
-var DEFAULT_MAX_SIZE = 1024;
+var DEFAULT_MAX_SIZE = 2048;
 var DEFAULT_PADDING = 2;
 
 /**

--- a/layout.js
+++ b/layout.js
@@ -1,23 +1,51 @@
+/**
+ * 
+ * Updated Aug 9-10, 2017 by Rhett Anderson
+ * 
+ * The spriter is a naive packer. It sorts images by size and then plops them down into a spritesheet. It's
+ * very willing to make a long horizontal line until it crosses the 2048 pixel boundary. This tends to leave
+ * a lot of unused texture memory.
+ * 
+ * Rather than rewrite the naive packer, I run it at different maximum widths (2048, 1024, 512) and compare
+ * the outcomes. I choose the one with the smallest number of pixels (area).
+ * 
+ * This is a pretty brute-force solution to improve the texture memory situation. A better next step than
+ * improving this would be to use a proven solution like texturePackerPro.
+ * 
+ */
+
+
 var Spritesheet = require('./Spritesheet');
 
 var DEFAULT_MAX_SIZE = 2048;
+var DEFAULT_MIN_SIZE = 512;
 var DEFAULT_PADDING = 2;
 
 /**
  * @returns {Spritesheet[]}
  */
+
 module.exports = function (images, opts) {
+  var bestArea = -1;
+  var bestNumSheets = 1000;
+  var bestX = DEFAULT_MAX_SIZE;
+
   if (!opts) { opts = {}; }
-  var maxSize = opts.maxSize !== undefined ? opts.maxSize : DEFAULT_MAX_SIZE;
+  var maxSizeX = opts.maxSize !== undefined ? opts.maxSize : DEFAULT_MAX_SIZE;
+  var maxSizeY = opts.maxSize !== undefined ? opts.maxSize : DEFAULT_MAX_SIZE;
   var padding = opts.padding !== undefined ? opts.padding : DEFAULT_PADDING;
   var powerOfTwoSheets = opts.powerOfTwoSheets !== undefined ? !!opts.powerOfTwoSheets : true;
   var name = opts.name || '';
   var ext = opts.ext || '';
+  var imageMemory = images;
 
-  var sheets = [];
-  var sheetIndex = 1;
-  var sheet = createSpritesheet();
-  var seen = {};
+  function highestBitSet(value) {
+    var r = 0;
+    while ((value >>= 1) > 0) {
+      r++;
+    }
+    return r;
+  }
 
   function createSpritesheet() {
     return new Spritesheet({
@@ -27,111 +55,163 @@ module.exports = function (images, opts) {
     });
   }
 
-  // handle large images
-  images = images.filter(function (image) {
-    if (image.contentWidth <= maxSize && image.contentHeight <= maxSize) {
-      return true;
+  var finalPass = false;
+  while ((maxSizeX >= DEFAULT_MIN_SIZE) || finalPass) {
+    if (finalPass) {
+      maxSizeX = bestX;
+    }
+    if (maxSizeX == DEFAULT_MIN_SIZE) {
+      maxSizeX = bestX;
+      finalPass = true;
     }
 
-    sheets.push(createSpritesheet().add(image, 0, 0));
-    return false;
-  }, this);
+    images = imageMemory;
+    var sheets = [];
+    var sheetIndex = 1;
+    var sheet = createSpritesheet();
+    var seen = {};
 
-  images.sort(sortLargestAreaFirst);
-
-  while (images.length) {
-    var points = [{x: 0, y: 0}];
-    while (points[0]) {
-      var index = getTopLeftPoint(points);
-      var pt = points[index];
-      points.splice(index, 1);
-      if (pt.x >= maxSize || pt.y >= maxSize) {
-        continue;
+    // handle large images
+    images = images.filter(function (image) {
+      if (image.contentWidth <= maxSizeY && image.contentHeight <= maxSizeX) {
+        return true;
       }
 
-      var right = maxSize + padding;
-      while (index < points.length) {
-        var rightPoint = points[index];
-        if (rightPoint.y == pt.y) {
-          points.splice(index, 1);
-        } else {
-          right = rightPoint.x;
-          break;
-        }
-      }
+      sheets.push(createSpritesheet().add(image, 0, 0));
+      return false;
+    }, this);
 
-      var i = 0;
-      var placed = false;
-      while (i < images.length) {
-        var image = images[i];
-        var x = pt.x;
-        var y = pt.y;
-        var width = image.contentWidth + padding;
-        var height = image.contentHeight + padding;
-        if (x > 0) { x += padding; width += padding; }
-        if (y > 0) { y += padding; height += padding; }
+    images.sort(sortLargestAreaFirst);
 
-        if (seen[image.hash]) {
-          var seenInfo = seen[image.hash];
-          seenInfo.sheet.addDuplicate(image, seenInfo.image);
-          images.splice(i, 1);
+    while (images.length) {
+      var points = [{ x: 0, y: 0 }];
+      var wide = 0;
+      var tall = 0;
+      while (points[0]) {
+        var index = getTopLeftPoint(points);
+        var pt = points[index];
+        points.splice(index, 1);
+        if (pt.x >= maxSizeX || pt.y >= maxSizeY) {
           continue;
         }
 
-        if (width <= right - pt.x && height <= maxSize + padding - pt.y) {
-          placed = true;
+        var right = maxSizeX + padding;
+        while (index < points.length) {
+          var rightPoint = points[index];
+          if (rightPoint.y == pt.y) {
+            points.splice(index, 1);
+          } else {
+            right = rightPoint.x;
+            break;
+          }
+        }
 
-          images.splice(i, 1);
-          sheet.add(image, x, y);
-          seen[image.hash] = {
-            image: image,
-            sheet: sheet
-          };
+        var i = 0;
+        var placed = false;
 
-          var nextX = pt.x + width;
-          var nextY = pt.y + height;
-          nextY += nextY & 0x1;
-          nextX += nextX & 0x1;
+        while (i < images.length) {
+          var image = images[i];
+          var x = pt.x;
+          var y = pt.y;
+          var width = image.contentWidth + padding;
+          var height = image.contentHeight + padding;
+          if (x > 0) { x += padding; width += padding; }
+          if (y > 0) { y += padding; height += padding; }
 
-          // bottom-left point
-          var found = addPoint(pt.x, nextY);
-          if (found > -1) {
-            points.splice(found, 1);
+          if (seen[image.hash]) {
+            var seenInfo = seen[image.hash];
+            seenInfo.sheet.addDuplicate(image, seenInfo.image);
+            images.splice(i, 1);
+            continue;
           }
 
-          // top-right point
-          if (nextX < maxSize && pt.y < maxSize) {
-            addPoint(nextX, pt.y);
+          if (width <= right - pt.x && height <= maxSizeY + padding - pt.y) {
+            placed = true;
+
+            if (pt.x + width > wide) {
+              wide = pt.x + width;
+            }
+            if (pt.y + height > tall) {
+              tall = pt.y + height;
+            }
+
+            images.splice(i, 1);
+            sheet.add(image, x, y);
+            seen[image.hash] = {
+              image: image,
+              sheet: sheet
+            };
+
+            var nextX = pt.x + width;
+            var nextY = pt.y + height;
+            nextY += nextY & 0x1;
+            nextX += nextX & 0x1;
+
+            // bottom-left point
+            var found = addPoint(pt.x, nextY);
+            if (found > -1) {
+              points.splice(found, 1);
+            }
+
+            // top-right point
+            if (nextX < maxSizeX && pt.y < maxSizeY) {
+              addPoint(nextX, pt.y);
+            }
+            break;
+          } else {
+            ++i;
           }
-          break;
-        } else {
-          ++i;
+        }
+
+        if (!placed) {
+          var leftPoint = null;
+          var rightPoint = null;
+          var n = points.length;
+          for (var i = 0; i < n; ++i) {
+            var e = points[i];
+            if (e.x < pt.x) {
+              leftPoint = e;
+              if (i + 1 < n) {
+                rightPoint = points[i + 1];
+              }
+            }
+          }
+
+          if (leftPoint && rightPoint && rightPoint.y < leftPoint.y) {
+            rightPoint.x = pt.x;
+          }
         }
       }
 
-      if (!placed) {
-        var leftPoint = null;
-        var rightPoint = null;
-        var n = points.length;
-        for (var i = 0; i < n; ++i) {
-          var e = points[i];
-          if (e.x < pt.x) {
-            leftPoint = e;
-            if (i + 1 < n) {
-              rightPoint = points[i + 1];
-            }
-          }
-        }
-
-        if (leftPoint && rightPoint && rightPoint.y < leftPoint.y) {
-          rightPoint.x = pt.x;
-        }
+      if (sheet.length > 0) {
+        sheets.push(sheet);
+        sheet = createSpritesheet();
       }
     }
 
-    if (sheet.length > 0 ) {
-      sheets.push(sheet);
-      sheet = createSpritesheet();
+    var po2x = 2 << highestBitSet(wide - 1);
+    var po2y = 2 << highestBitSet(tall - 1);
+    var po2area = po2x * po2y;
+
+    if ((bestArea < 0 || po2area <= bestArea) && (sheets.length <= bestNumSheets)) {
+      bestArea = po2area;
+      bestX = po2x;
+
+      bestNumSheets = sheets.length;
+    }
+
+    maxSizeX /= 2;
+
+    if (finalPass) {
+      finalPass = false;
+      maxSizeX = 0;
+    } else {
+      if (maxSizeX == DEFAULT_MIN_SIZE) {
+        finalPass = true;
+      }
+      if (tall > DEFAULT_MAX_SIZE) {
+        finalPass = true;
+      }
     }
   }
 
@@ -154,7 +234,7 @@ module.exports = function (images, opts) {
       }
     }
 
-    points.splice(insertAt, 0, {x: x, y: y});
+    points.splice(insertAt, 0, { x: x, y: y });
     return -1;
   }
 };

--- a/layout.js
+++ b/layout.js
@@ -1,5 +1,9 @@
 
 /**
+ * Update Aug 13, by Rhett Anderson
+ * 
+ * Handle degenerate case of having only two bitmaps differently. This prevents the clouds from being split
+ * into two sheets.
  * 
  * Update Aug 12, by Rhett Anderson
  * 
@@ -30,8 +34,6 @@ var DEFAULT_PADDING = 2;
  */
 
 module.exports = function (images, opts) {
-  var logdata = '';
-
   var bestArea = -1;
   var bestNumSheets = 1000;
   var bestX = DEFAULT_MAX_SIZE;
@@ -94,6 +96,8 @@ module.exports = function (images, opts) {
         widest = images[0].contentWidth + DEFAULT_PADDING;
       }
     }
+
+    var numBitmaps = images.length;
 
     while (images.length) {
       var points = [{ x: 0, y: 0 }];
@@ -215,6 +219,9 @@ module.exports = function (images, opts) {
     }
     if (maxSizeX < 64) {
       maxSizeX = 64;
+    }
+    if (numBitmaps < 3) {
+      maxSizeX = DEFAULT_MAX_SIZE;
     }
   }
 

--- a/layout.js
+++ b/layout.js
@@ -1,3 +1,31 @@
+
+/**
+ * Update Aug 16, 2017 by Rhett Anderson
+ * 
+ * Fixed infinite loop when spriting in cats data (also fixes one Everwing asset that was breaking into
+ *  two sheets)
+ * Changed for loop to while loop and added some early exits for speeding up the process
+ * (Note: some sprite sheets may get bigger and some may get smaller with this change. It should not
+ *  be a big net change)
+ * 
+ * Update Aug 12, 2017 by Rhett Anderson
+ * 
+ * Cleaner loop. Smarter packing.
+ * 
+ * Updated Aug 9-10, 2017 by Rhett Anderson
+ * 
+ * The spriter is a naive packer. It sorts images by size and then plops them down into a spritesheet. It's
+ * very willing to make a long horizontal line until it crosses the 2048 pixel boundary. This tends to leave
+ * a lot of unused texture memory.
+ * 
+ * Rather than rewrite the naive packer, I run it at different maximum widths (2048, 1024, 512) and compare
+ * the outcomes. I choose the one with the smallest number of pixels (area).
+ * 
+ * This is a pretty brute-force solution to improve the texture memory situation. Packing algorithms are not
+ * trivial. A better next step than improving this would be to use a proven solution like texturePackerPro.
+ * 
+ */
+
 var Spritesheet = require('./Spritesheet');
 
 var DEFAULT_MAX_SIZE = 2048;
@@ -6,20 +34,31 @@ var DEFAULT_PADDING = 2;
 /**
  * @returns {Spritesheet[]}
  */
+
 module.exports = function (images, opts) {
+  var bestArea = -1;
+  var bestNumSheets = 1000;
+  var bestX = DEFAULT_MAX_SIZE;
+
   if (!opts) { opts = {}; }
-  var maxSize = opts.maxSize !== undefined ? opts.maxSize : DEFAULT_MAX_SIZE;
+  var maxSizeX = opts.maxSize !== undefined ? opts.maxSize : DEFAULT_MAX_SIZE;
+  var maxSizeY = opts.maxSize !== undefined ? opts.maxSize : DEFAULT_MAX_SIZE;
   var padding = opts.padding !== undefined ? opts.padding : DEFAULT_PADDING;
   var powerOfTwoSheets = opts.powerOfTwoSheets !== undefined ? !!opts.powerOfTwoSheets : true;
   var name = opts.name || '';
   var ext = opts.ext || '';
+  var imageMemory = images;
 
-  var sheets = [];
-  var sheetIndex = 1;
-  var sheet = createSpritesheet();
-  var seen = {};
+  // used for the calculation of the power of two that a texture will fit into
+  function highestBitSet (value) {
+    var r = 0;
+    while ((value >>= 1) > 0) {
+      r++;
+    }
+    return r;
+  }
 
-  function createSpritesheet() {
+  function createSpritesheet () {
     return new Spritesheet({
       name: name + (sheetIndex++) + ext,
       padding: padding,
@@ -27,118 +66,186 @@ module.exports = function (images, opts) {
     });
   }
 
-  // handle large images
-  images = images.filter(function (image) {
-    if (image.contentWidth <= maxSize && image.contentHeight <= maxSize) {
-      return true;
+  var finalpass = 5;
+  var pass = 0;
+
+  while(pass <= finalpass) {
+    if (pass == finalpass) {
+      maxSizeX = bestX;
     }
 
-    sheets.push(createSpritesheet().add(image, 0, 0));
-    return false;
-  }, this);
+    images = imageMemory;
+    var sheets = [];
+    var sheetIndex = 1;
+    var sheet = createSpritesheet();
+    var seen = {};
 
-  images.sort(sortLargestAreaFirst);
-
-  while (images.length) {
-    var points = [{x: 0, y: 0}];
-    while (points[0]) {
-      var index = getTopLeftPoint(points);
-      var pt = points[index];
-      points.splice(index, 1);
-      if (pt.x >= maxSize || pt.y >= maxSize) {
-        continue;
+    // handle large images
+    images = images.filter(function (image) {
+      if (image.contentWidth <= maxSizeY && image.contentHeight <= maxSizeX) {
+        return true;
       }
 
-      var right = maxSize + padding;
-      while (index < points.length) {
-        var rightPoint = points[index];
-        if (rightPoint.y == pt.y) {
-          points.splice(index, 1);
-        } else {
-          right = rightPoint.x;
-          break;
-        }
+      sheets.push(createSpritesheet().add(image, 0, 0));
+      return false;
+    }, this);
+
+    images.sort(sortLargestAreaFirst);
+    var greatestX = 0;
+    var greatestY = 0;
+
+    var widest = 0;
+    for (var i = 0; i < images.length; i++) {
+      if (images[0].contentWidth + DEFAULT_PADDING > widest) {
+        widest = images[0].contentWidth + DEFAULT_PADDING;
       }
+    }
 
-      var i = 0;
-      var placed = false;
-      while (i < images.length) {
-        var image = images[i];
-        var x = pt.x;
-        var y = pt.y;
-        var width = image.contentWidth + padding;
-        var height = image.contentHeight + padding;
-        if (x > 0) { x += padding; width += padding; }
-        if (y > 0) { y += padding; height += padding; }
+    var numBitmaps = images.length;
 
-        if (seen[image.hash]) {
-          var seenInfo = seen[image.hash];
-          seenInfo.sheet.addDuplicate(image, seenInfo.image);
-          images.splice(i, 1);
+    while (images.length) {
+      var points = [{ x: 0, y: 0 }];
+      while (points[0]) {
+        var index = getTopLeftPoint(points);
+        var pt = points[index];
+        points.splice(index, 1);
+        if (pt.x >= maxSizeX || pt.y >= maxSizeY) {
           continue;
         }
 
-        if (width <= right - pt.x && height <= maxSize + padding - pt.y) {
-          placed = true;
-
-          images.splice(i, 1);
-          sheet.add(image, x, y);
-          seen[image.hash] = {
-            image: image,
-            sheet: sheet
-          };
-
-          var nextX = pt.x + width;
-          var nextY = pt.y + height;
-          nextY += nextY & 0x1;
-          nextX += nextX & 0x1;
-
-          // bottom-left point
-          var found = addPoint(pt.x, nextY);
-          if (found > -1) {
-            points.splice(found, 1);
+        var right = maxSizeX + padding;
+        while (index < points.length) {
+          var rightPoint = points[index];
+          if (rightPoint.y == pt.y) {
+            points.splice(index, 1);
+          } else {
+            right = rightPoint.x;
+            break;
           }
-
-          // top-right point
-          if (nextX < maxSize && pt.y < maxSize) {
-            addPoint(nextX, pt.y);
-          }
-          break;
-        } else {
-          ++i;
         }
-      }
 
-      if (!placed) {
-        var leftPoint = null;
-        var rightPoint = null;
-        var n = points.length;
-        for (var i = 0; i < n; ++i) {
-          var e = points[i];
-          if (e.x < pt.x) {
-            leftPoint = e;
-            if (i + 1 < n) {
-              rightPoint = points[i + 1];
+        var i = 0;
+        var placed = false;
+
+        while (i < images.length) {
+          var image = images[i];
+          var x = pt.x;
+          var y = pt.y;
+          var width = image.contentWidth + padding;
+          var height = image.contentHeight + padding;
+          if (x > 0) { x += padding; width += padding; }
+          if (y > 0) { y += padding; height += padding; }
+
+          if (seen[image.hash]) {
+            var seenInfo = seen[image.hash];
+            seenInfo.sheet.addDuplicate(image, seenInfo.image);
+            images.splice(i, 1);
+            continue;
+          }
+
+          if (width <= right - pt.x && height <= maxSizeY + padding - pt.y) {
+            placed = true;
+            if (pt.x + width > greatestX) {
+              greatestX = pt.x + width;
+            }
+            if (pt.y + height > greatestY) {
+              greatestY = pt.y + height;
+            }
+
+            images.splice(i, 1);
+            sheet.add(image, x, y);
+            seen[image.hash] = {
+              image: image,
+              sheet: sheet
+            };
+
+            var nextX = pt.x + width;
+            var nextY = pt.y + height;
+            nextY += nextY & 0x1;
+            nextX += nextX & 0x1;
+
+            // bottom-left point
+            var found = addPoint(pt.x, nextY);
+            if (found > -1) {
+              points.splice(found, 1);
+            }
+
+            // top-right point
+            if (nextX < maxSizeX && pt.y < maxSizeY) {
+              addPoint(nextX, pt.y);
+            }
+            break;
+          } else {
+            ++i;
+          }
+        }
+
+        if (!placed) {
+          var leftPoint = null;
+          var rightPoint = null;
+          var n = points.length;
+          for (var i = 0; i < n; ++i) {
+            var e = points[i];
+            if (e.x < pt.x) {
+              leftPoint = e;
+              if (i + 1 < n) {
+                rightPoint = points[i + 1];
+              }
             }
           }
-        }
 
-        if (leftPoint && rightPoint && rightPoint.y < leftPoint.y) {
-          rightPoint.x = pt.x;
+          if (leftPoint && rightPoint && rightPoint.y < leftPoint.y) {
+            rightPoint.x = pt.x;
+          }
         }
+      }
+
+      if (sheet.length > 0) {
+        sheets.push(sheet);
+        sheet = createSpritesheet();
       }
     }
 
-    if (sheet.length > 0 ) {
-      sheets.push(sheet);
-      sheet = createSpritesheet();
+    var po2x = 2 << highestBitSet(greatestX - padding);
+    var po2y = 2 << highestBitSet(greatestY - padding);
+
+    var po2area = po2x * po2y;
+
+    if ((bestArea < 0 || po2area <= bestArea) && (sheets.length <= bestNumSheets)) {
+      bestArea = po2area;
+      bestX = po2x;
+      bestNumSheets = sheets.length;
     }
+
+    maxSizeX = po2x / 2;
+    if (maxSizeX < widest) {
+      maxSizeX *= 2;
+    }
+
+    if ((maxSizeX < 64) && (pass < finalpass)) {
+      pass = finalpass - 1;
+    }
+    
+    if ((numBitmaps < 3) && (pass < finalpass)) {
+      pass = finalpass - 1;
+    }
+
+    if (sheets > bestNumSheets) {
+      pass = finalpass - 1;
+    }
+
+    if (bestX > DEFAULT_MAX_SIZE) {
+      bestX = DEFAULT_MAX_SIZE;
+      maxSizeX = bestX / 2;
+    }
+
+    pass++;
   }
 
   return sheets;
 
   // returns index of found point, or inserts the point and returns -1
-  function addPoint(x, y) {
+  function addPoint (x, y) {
     var i = points.length;
     var insertAt = i;
     while (i-- > 0) {
@@ -154,16 +261,16 @@ module.exports = function (images, opts) {
       }
     }
 
-    points.splice(insertAt, 0, {x: x, y: y});
+    points.splice(insertAt, 0, { x: x, y: y });
     return -1;
   }
 };
 
-function sortLargestAreaFirst(a, b) {
+function sortLargestAreaFirst (a, b) {
   return b.contentArea - a.contentArea;
 }
 
-function getTopLeftPoint(points) {
+function getTopLeftPoint (points) {
   var index = 0;
   var minX = points[0].x;
   var minY = points[0].y;

--- a/layout.js
+++ b/layout.js
@@ -15,13 +15,12 @@ module.exports = function (images, opts) {
   var ext = opts.ext || '';
 
   var sheets = [];
-  var sheetIndex = 1;
   var sheet = createSpritesheet();
   var seen = {};
 
   function createSpritesheet() {
     return new Spritesheet({
-      name: name + (sheetIndex++) + ext,
+      name: name + ext,
       padding: padding,
       powerOfTwoSheets: powerOfTwoSheets
     });

--- a/layout.js
+++ b/layout.js
@@ -15,12 +15,13 @@ module.exports = function (images, opts) {
   var ext = opts.ext || '';
 
   var sheets = [];
+  var sheetIndex = 1;
   var sheet = createSpritesheet();
   var seen = {};
 
   function createSpritesheet() {
     return new Spritesheet({
-      name: name + ext,
+      name: name + (sheetIndex++) + ext,
       padding: padding,
       powerOfTwoSheets: powerOfTwoSheets
     });

--- a/package.json
+++ b/package.json
@@ -1,80 +1,12 @@
 {
-  "_args": [
-    [
-      {
-        "raw": "devkit-spriter@git+https://github.com/gameclosure/devkit-spriter.git#es6",
-        "scope": null,
-        "escapedName": "devkit-spriter",
-        "name": "devkit-spriter",
-        "rawSpec": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
-        "spec": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
-        "type": "hosted",
-        "hosted": {
-          "type": "github",
-          "ssh": "git@github.com:gameclosure/devkit-spriter.git#es6",
-          "sshUrl": "git+ssh://git@github.com/gameclosure/devkit-spriter.git#es6",
-          "httpsUrl": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
-          "gitUrl": "git://github.com/gameclosure/devkit-spriter.git#es6",
-          "shortcut": "github:gameclosure/devkit-spriter#es6",
-          "directUrl": "https://raw.githubusercontent.com/gameclosure/devkit-spriter/es6/package.json"
-        }
-      },
-      "/Users/jimbo3744/Library/Application Support/devkit/cache/devkit-core"
-    ]
-  ],
-  "_from": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
-  "_id": "devkit-spriter@0.0.9",
-  "_inCache": true,
-  "_location": "/devkit-spriter",
-  "_phantomChildren": {},
-  "_requested": {
-    "raw": "devkit-spriter@git+https://github.com/gameclosure/devkit-spriter.git#es6",
-    "scope": null,
-    "escapedName": "devkit-spriter",
-    "name": "devkit-spriter",
-    "rawSpec": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
-    "spec": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
-    "type": "hosted",
-    "hosted": {
-      "type": "github",
-      "ssh": "git@github.com:gameclosure/devkit-spriter.git#es6",
-      "sshUrl": "git+ssh://git@github.com/gameclosure/devkit-spriter.git#es6",
-      "httpsUrl": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
-      "gitUrl": "git://github.com/gameclosure/devkit-spriter.git#es6",
-      "shortcut": "github:gameclosure/devkit-spriter#es6",
-      "directUrl": "https://raw.githubusercontent.com/gameclosure/devkit-spriter/es6/package.json"
-    }
-  },
-  "_requiredBy": [
-    "/"
-  ],
-  "_resolved": "git+https://github.com/gameclosure/devkit-spriter.git#b418f627320b80cf315b321ddd017a5ade27c934",
-  "_shasum": "ecb2c9a330dcd977a30951d07bd24a38d526878c",
-  "_shrinkwrap": null,
-  "_spec": "devkit-spriter@git+https://github.com/gameclosure/devkit-spriter.git#es6",
-  "_where": "/Users/jimbo3744/Library/Application Support/devkit/cache/devkit-core",
-  "author": {
-    "name": "Martin Hunt"
-  },
-  "bugs": {
-    "url": "https://github.com/gameclosure/devkit-spriter/issues"
-  },
+  "name": "devkit-spriter",
+  "repository": "https://github.com/gameclosure/devkit-spriter",
+  "author": "Martin Hunt",
+  "version": "0.0.9",
+  "description": "a 2D spriter for the DevKit game engine",
   "dependencies": {
     "bluebird": "^2.10.2",
     "graceful-fs": "^4.1.2",
     "jimp": "git+https://github.com/mgh/jimp.git"
-  },
-  "description": "a 2D spriter for the DevKit game engine",
-  "devDependencies": {},
-  "gitHead": "b418f627320b80cf315b321ddd017a5ade27c934",
-  "homepage": "https://github.com/gameclosure/devkit-spriter#readme",
-  "name": "devkit-spriter",
-  "optionalDependencies": {},
-  "readme": "# devkit-spriter\n\nThe devkit-spriter package provides three functions for the devkit build process:\n\n 1. loading images\n 2. spriting images into spritesheets\n 3. caching spritesheets\n\n## Loading Images\n\nTo load images, use the `loadImages(filenames : String[]) :\nPromise<ImageInfo[]>` function:\n\n    var spriter = require('devkit-spriter');\n    spriter.loadImages(['image1.png', 'image2.png'])\n        .then(function (images) {\n            // images is an array of ImageInfo objects\n        });\n\nAn `ImageInfo` object is a representation of an image that the spriter can use\nto create spritesheets.  It has the following properites:\n\n - `x : int` the location of the image in a spritesheet\n - `y : int` the location of the image in a spritesheet\n - `filename : string` the full path to the image on disk\n - `hash : string` an md5 hash of the image bitmap\n - `buffer : ImageBuffer` the pixels of the image wrapped in a Jimp object\n   (see https://github.com/oliver-moran/jimp). An ImageBuffer extends the Jimp\n   base class with a `drawImage` call (based on the HTML5 canvas `drawImage`\n   call and promisifies `getBuffer` and `write`.\n - `width : int` the original image width\n - `height : int` the original image height\n - `area : int` the image's area\n - `data : Buffer` the raw data in a node `Buffer`, alias for `buffer.bitmap.data`\n - `depth : int` the number of channels for the image, e.g. 4 for rgba\n - `hasAlphaChannel : boolean` true if the depth is 4\n - `margin : {top : int, right : int, bottom : int, left : int}` the size of\n   the margins around the image (transparent regions in original image)\n - `contentWidth : int` the width minus the margins\n - `contentHeight : int` the height minus the margins\n - `contentArea : int` the content area, the number of pixels this image will\n   occupy on a spritesheet (excluding spritesheet padding)\n\n## Spriting images\n\nTo sprite images, first load them into ImageInfo objects.  Then call\n`layout(ImageInfo[], opts) : Spritesheet[]`:\n\n    var spritesheets = spriter.layout(images);\n\nNote that this is a synchronous call since no IO is performed.  This call\nmaybe expensive, depending on how many images you provide.\n\n`opts` can include:\n - `padding : int` number of pixels on each side of an image to pad out the\n   image.  Padding works by extending the border of the image.  Defaults to\n   `2`, which prevents most texture artifacts in OpenGL.\n - `maxSize : int` the largest dimension of a spritesheet.  Spritesheets\n   cannot exceed this value in either width or height.  Defaults to `1024`.\n - `powerOfTwoSheets : boolean` whether sheets should round their dimensions\n   up to the nearest power of two.  Defaults to `true`.\n - `name : string` a prefix for spritesheet names\n - `ext : string` a postfix for all spritesheet names\n\n## Caching spritesheets\n\nThe spriter provides utility functions for reading and writing to a disk\ncache.  It verifies the integrity of the disk cache before returning cached\nresults.  Call `loadCache(cacheFile : string, outputDirectory :\nstring) : Promise<DiskCache>` to load a disk cache file:\n\n    var group = 'group1';\n    var filenames = ['image1.png', 'image2.png'];\n\n    spriter.loadCache('.my-cache-file', 'build/spritesheets/')\n        .get(group, filenames)\n        .then(function () {\n            // cached\n        })\n        .catch(Spriter.NotCachedError, function () {\n            // should resprite\n        });\n\nThe spriter is commonly used with groups of spritesheets, since a common use\ncase is to sprite images that will probably be used together into the same\nspritesheet(s).  For example, all sprites in a common animation should be\nplaced in a single group.  Compression is another example of grouping: images\ncompressed as jpgs should be sprited separately from images compressed as pngs\nso that the resulting spritesheets can be compressed correctly.\n\nCalling `get` on `DiskCache` verifies the following:\n\n - no files were added to the group\n - no files were removed from the group\n - no files have changed in the group (comparing modified times)\n - the generated spritesheet files still exist\n - the spritesheet data looks valid (every sheet has a name and images, every\n   image in the spritesheet is in the group)\n\n",
-  "readmeFilename": "Readme.md",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/gameclosure/devkit-spriter.git"
-  },
-  "version": "0.0.9"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,80 @@
 {
-  "name": "devkit-spriter",
-  "repository": "https://github.com/gameclosure/devkit-spriter",
-  "author": "Martin Hunt",
-  "version": "0.0.9",
-  "description": "a 2D spriter for the DevKit game engine",
+  "_args": [
+    [
+      {
+        "raw": "devkit-spriter@git+https://github.com/gameclosure/devkit-spriter.git#es6",
+        "scope": null,
+        "escapedName": "devkit-spriter",
+        "name": "devkit-spriter",
+        "rawSpec": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
+        "spec": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
+        "type": "hosted",
+        "hosted": {
+          "type": "github",
+          "ssh": "git@github.com:gameclosure/devkit-spriter.git#es6",
+          "sshUrl": "git+ssh://git@github.com/gameclosure/devkit-spriter.git#es6",
+          "httpsUrl": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
+          "gitUrl": "git://github.com/gameclosure/devkit-spriter.git#es6",
+          "shortcut": "github:gameclosure/devkit-spriter#es6",
+          "directUrl": "https://raw.githubusercontent.com/gameclosure/devkit-spriter/es6/package.json"
+        }
+      },
+      "/Users/jimbo3744/Library/Application Support/devkit/cache/devkit-core"
+    ]
+  ],
+  "_from": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
+  "_id": "devkit-spriter@0.0.9",
+  "_inCache": true,
+  "_location": "/devkit-spriter",
+  "_phantomChildren": {},
+  "_requested": {
+    "raw": "devkit-spriter@git+https://github.com/gameclosure/devkit-spriter.git#es6",
+    "scope": null,
+    "escapedName": "devkit-spriter",
+    "name": "devkit-spriter",
+    "rawSpec": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
+    "spec": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
+    "type": "hosted",
+    "hosted": {
+      "type": "github",
+      "ssh": "git@github.com:gameclosure/devkit-spriter.git#es6",
+      "sshUrl": "git+ssh://git@github.com/gameclosure/devkit-spriter.git#es6",
+      "httpsUrl": "git+https://github.com/gameclosure/devkit-spriter.git#es6",
+      "gitUrl": "git://github.com/gameclosure/devkit-spriter.git#es6",
+      "shortcut": "github:gameclosure/devkit-spriter#es6",
+      "directUrl": "https://raw.githubusercontent.com/gameclosure/devkit-spriter/es6/package.json"
+    }
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "git+https://github.com/gameclosure/devkit-spriter.git#b418f627320b80cf315b321ddd017a5ade27c934",
+  "_shasum": "ecb2c9a330dcd977a30951d07bd24a38d526878c",
+  "_shrinkwrap": null,
+  "_spec": "devkit-spriter@git+https://github.com/gameclosure/devkit-spriter.git#es6",
+  "_where": "/Users/jimbo3744/Library/Application Support/devkit/cache/devkit-core",
+  "author": {
+    "name": "Martin Hunt"
+  },
+  "bugs": {
+    "url": "https://github.com/gameclosure/devkit-spriter/issues"
+  },
   "dependencies": {
     "bluebird": "^2.10.2",
     "graceful-fs": "^4.1.2",
     "jimp": "git+https://github.com/mgh/jimp.git"
-  }
+  },
+  "description": "a 2D spriter for the DevKit game engine",
+  "devDependencies": {},
+  "gitHead": "b418f627320b80cf315b321ddd017a5ade27c934",
+  "homepage": "https://github.com/gameclosure/devkit-spriter#readme",
+  "name": "devkit-spriter",
+  "optionalDependencies": {},
+  "readme": "# devkit-spriter\n\nThe devkit-spriter package provides three functions for the devkit build process:\n\n 1. loading images\n 2. spriting images into spritesheets\n 3. caching spritesheets\n\n## Loading Images\n\nTo load images, use the `loadImages(filenames : String[]) :\nPromise<ImageInfo[]>` function:\n\n    var spriter = require('devkit-spriter');\n    spriter.loadImages(['image1.png', 'image2.png'])\n        .then(function (images) {\n            // images is an array of ImageInfo objects\n        });\n\nAn `ImageInfo` object is a representation of an image that the spriter can use\nto create spritesheets.  It has the following properites:\n\n - `x : int` the location of the image in a spritesheet\n - `y : int` the location of the image in a spritesheet\n - `filename : string` the full path to the image on disk\n - `hash : string` an md5 hash of the image bitmap\n - `buffer : ImageBuffer` the pixels of the image wrapped in a Jimp object\n   (see https://github.com/oliver-moran/jimp). An ImageBuffer extends the Jimp\n   base class with a `drawImage` call (based on the HTML5 canvas `drawImage`\n   call and promisifies `getBuffer` and `write`.\n - `width : int` the original image width\n - `height : int` the original image height\n - `area : int` the image's area\n - `data : Buffer` the raw data in a node `Buffer`, alias for `buffer.bitmap.data`\n - `depth : int` the number of channels for the image, e.g. 4 for rgba\n - `hasAlphaChannel : boolean` true if the depth is 4\n - `margin : {top : int, right : int, bottom : int, left : int}` the size of\n   the margins around the image (transparent regions in original image)\n - `contentWidth : int` the width minus the margins\n - `contentHeight : int` the height minus the margins\n - `contentArea : int` the content area, the number of pixels this image will\n   occupy on a spritesheet (excluding spritesheet padding)\n\n## Spriting images\n\nTo sprite images, first load them into ImageInfo objects.  Then call\n`layout(ImageInfo[], opts) : Spritesheet[]`:\n\n    var spritesheets = spriter.layout(images);\n\nNote that this is a synchronous call since no IO is performed.  This call\nmaybe expensive, depending on how many images you provide.\n\n`opts` can include:\n - `padding : int` number of pixels on each side of an image to pad out the\n   image.  Padding works by extending the border of the image.  Defaults to\n   `2`, which prevents most texture artifacts in OpenGL.\n - `maxSize : int` the largest dimension of a spritesheet.  Spritesheets\n   cannot exceed this value in either width or height.  Defaults to `1024`.\n - `powerOfTwoSheets : boolean` whether sheets should round their dimensions\n   up to the nearest power of two.  Defaults to `true`.\n - `name : string` a prefix for spritesheet names\n - `ext : string` a postfix for all spritesheet names\n\n## Caching spritesheets\n\nThe spriter provides utility functions for reading and writing to a disk\ncache.  It verifies the integrity of the disk cache before returning cached\nresults.  Call `loadCache(cacheFile : string, outputDirectory :\nstring) : Promise<DiskCache>` to load a disk cache file:\n\n    var group = 'group1';\n    var filenames = ['image1.png', 'image2.png'];\n\n    spriter.loadCache('.my-cache-file', 'build/spritesheets/')\n        .get(group, filenames)\n        .then(function () {\n            // cached\n        })\n        .catch(Spriter.NotCachedError, function () {\n            // should resprite\n        });\n\nThe spriter is commonly used with groups of spritesheets, since a common use\ncase is to sprite images that will probably be used together into the same\nspritesheet(s).  For example, all sprites in a common animation should be\nplaced in a single group.  Compression is another example of grouping: images\ncompressed as jpgs should be sprited separately from images compressed as pngs\nso that the resulting spritesheets can be compressed correctly.\n\nCalling `get` on `DiskCache` verifies the following:\n\n - no files were added to the group\n - no files were removed from the group\n - no files have changed in the group (comparing modified times)\n - the generated spritesheet files still exist\n - the spritesheet data looks valid (every sheet has a name and images, every\n   image in the spritesheet is in the group)\n\n",
+  "readmeFilename": "Readme.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gameclosure/devkit-spriter.git"
+  },
+  "version": "0.0.9"
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   "dependencies": {
     "bluebird": "^2.10.2",
     "graceful-fs": "^4.1.2",
-    "jimp": "git+https://github.com/mgh/jimp.git"
+    "jimp": "^0.2.27"
   }
 }


### PR DESCRIPTION
 * Update Oct 27, 2017 by Rhett Anderson
 * Fix infinite loop that happens when an image that's too large to fit spills out into a second sheet

Details:
Spriter tries various size of maximum width to try to find the best power-of-2 packing. In a couple of very rare cases, one of the maxwidth values we try is smaller than the width of an image we're trying to put on it. This causes an infinite loop during the build. This fix bails out in such a case. This does not hurt the packing.
 